### PR TITLE
Add .input border to the map

### DIFF
--- a/place.php
+++ b/place.php
@@ -136,7 +136,7 @@
   public function map () {
     # Wrapper
     $map_content = new Brick('div');
-    $map_content->addClass('field-content field-google-map-ui');
+    $map_content->addClass('field-content field-google-map-ui input');
     $map_content->data($this->center);
 
     return $map_content;


### PR DESCRIPTION
This change adds the .input class to the map element so that it gets the grey border around it like the other panel elements. It is also kind of an input element as the marker can be used to set the location.
